### PR TITLE
[FIX] Deleting of useless function

### DIFF
--- a/src/drivers/idt/handler.c
+++ b/src/drivers/idt/handler.c
@@ -23,11 +23,6 @@ void irq_handler(registers_t *regs)
     }
 }
 
-void register_handler(uint8_t n, handler_t handler)
-{
-    handlers[n] = handler;
-}
-
 void set_callback(uint8_t index, handler_t call)
 {
     handlers[index] = call;

--- a/src/drivers/idt/handler.h
+++ b/src/drivers/idt/handler.h
@@ -18,13 +18,6 @@ extern void isr_handler(registers_t *regs);
 extern void irq_handler(registers_t *regs);
 
 /**
- * @brief register an handler for an interrupt
- * @param n the interrupt number
- * @param handler the handler
-*/
-void register_handler(uint8_t n, handler_t handler);
-
-/**
  * @brief set the callback of an interrupt
  * @param index the interrupt number
  * @param call the callback


### PR DESCRIPTION
Deleting of useless function register_handler that register a callback, register_handler already exists and do the same